### PR TITLE
Use TemplateDirectory as a key in the Templates cache

### DIFF
--- a/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
+++ b/src/NJsonSchema.CodeGeneration/DefaultTemplateFactory.cs
@@ -118,7 +118,8 @@ namespace NJsonSchema.CodeGeneration
         private sealed class LiquidTemplate : ITemplate
         {
             internal const string TemplateTagName = "template";
-            private static readonly ConcurrentDictionary<(string, string), IFluidTemplate> Templates = new ConcurrentDictionary<(string, string), IFluidTemplate>();
+            // PATCH: use TemplateDirectory as a 3rd key to allow different templates for different folders
+            private static readonly ConcurrentDictionary<(string, string, string), IFluidTemplate> Templates = new ConcurrentDictionary<(string, string, string), IFluidTemplate>();
 
             static LiquidTemplate()
             {
@@ -174,8 +175,9 @@ namespace NJsonSchema.CodeGeneration
 
                 try
                 {
-                    // use language and template name as key for faster lookup than using the content
-                    var key = (_language, _template);
+                    // PATCH: use TemplateDirectory as a 3rd key to allow different templates for different folders
+                    // use language, template name and TemplateDirectory as key for faster lookup than using the content
+                    var key = (_language, _template, _settings.TemplateDirectory);
                     var template = Templates.GetOrAdd(key, _ =>
                     {
                         // our matching expects unix new lines


### PR DESCRIPTION
`api-client-generator` users want to have custom templates for their repositories or for specific folders inside their repos. NJsonSchema has Templates cache that doesn't depend on TemplateDirectory so you can't use different templates for different folders during the tool execution.

There are two ways to support this feature:
1. Modify DefaultTemplateFactory.cs inside NJsonSchema fork
2. Clone and modify DefaultTemplateFactory.cs inside api-client-generator repository and assign it here https://github.com/servicetitan/api-client-generator/blob/master/src/ApiClientGenerator/TypeScript/ITypeScriptGeneratorSettingsFactory.cs#L97

Since we have our own fork of NJsonSchema, option one introduces less code duplication, so I decided to go ahead with it for now. 